### PR TITLE
Add CSS fix for issue where document outline overflows off the screen

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -1,3 +1,11 @@
 body {
   font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
+
+/* Fix document outline in the right sidebar from overflowing off the page.
+ *
+ * See: <https://github.com/jupyter-book/myst-theme/pull/665>
+ */
+[aria-label="Document Outline"] {
+  max-height: calc(100vh - 100px) !important;
+}


### PR DESCRIPTION
See: <https://github.com/jupyter-book/myst-theme/pull/665>

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--14.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->