### PR TITLE
Add jupyter-myst-build-proxy to Docker environment

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -47,3 +47,8 @@ dependencies:
   # GitHub utilities
   - "gh"
   - "gh-scoped-creds"
+
+  # Pip-only dependencies... ideally we get these on conda-forge.
+  - "pip"
+  - pip:
+    - "jupyter-myst-build-proxy"


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--21.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->