### PR TITLE
Add jupyter-server-proxy to docker image

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -48,7 +48,10 @@ dependencies:
   - "gh"
   - "gh-scoped-creds"
 
+  # Infrastructure
+  - "jupyter-server-proxy"  # Enable proxying MyST sites built from CLI, accessed at `$PREFIX/proxy/$PORT`
+
   # Pip-only dependencies... ideally we get these on conda-forge.
   - "pip"
   - pip:
-    - "jupyter-myst-build-proxy"
+    - "jupyter-myst-build-proxy"  # Automatic build and proxying of MyST sites, triggered by requests to `$PREFIX/myst-build/$PATH_TO_MYST_PROJECT`


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--22.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->