### PR TITLE
Add dogfooding instructions for MyST previews with jupyter-myst-build-proxy

### DIFF
--- a/for-instructors/dogfooding.md
+++ b/for-instructors/dogfooding.md
@@ -23,18 +23,7 @@ We have installed
 [`jupyter-myst-build-proxy`](https://github.com/ryanlovett/jupyter-myst-build-proxy)
 which builds the MyST site on-demand.
 
-To view your built site:
-
-* Copy the URL of your server (e.g. Matt's URL is
-  `https://hub.cryointhecloud.com/user/mfisher87/lab`)
-* Open a new browser tab
-* Paste the URL in the URL bar
-* Replace `/lab` with `/myst-build/$DIRECTORY_OF_MYST_PROJECT`; for example, Matt's
-  project is at `~/workshop-open-source-geospatial`, so his URL would be
-  `https://hub.cryointhecloud.com/user/mfisher87/myst-build/workshop-open-source-geospatial`.
-
-At this point you should see the build progress in your browser. It should only take a
-few seconds, and then you'll see your fully-built MyST site!
+See [](../reference/04-using-myst.md) for instructions.
 
 
 ### Tradeoffs
@@ -43,14 +32,6 @@ This extension uses the `myst build --html` command instead of `myst
 start`
 ([read more here](https://github.com/ryanlovett/jupyter-myst-build-proxy/issues/8)).
 As a consequence, builds are not triggered automatically when edits are performed.
-
-Builds are triggered in two ways:
-
-* First build: When the user first accesses the URL corresponding to the MyST project,
-  and the built site is not found, a build is triggered.
-  A nice UI shows the user progress in their browser during the build.
-* Subsequent builds: The user must append `/?rebuild=1` to the URL to trigger subsequent
-  builds.
 
 There is currently no known way to use the MyST preview server `myst start` in a
 JupyterLab environment. See https://github.com/jupyter-book/mystmd/issues/302

--- a/reference/04-using-myst.md
+++ b/reference/04-using-myst.md
@@ -1,0 +1,26 @@
+# 📝 Using MyST
+
+## Previewing your MyST site
+
+### First time
+
+To view your built site:
+
+* Copy the URL of your server (e.g. Matt's URL is
+  `https://hub.cryointhecloud.com/user/mfisher87/lab`)
+* Open a new browser tab
+* Paste the URL in the URL bar
+* Replace `/lab` with `/myst-build/$DIRECTORY_OF_MYST_PROJECT`; for example, Matt's
+  project is at `~/workshop-open-source-geospatial`, so his URL would be
+  `https://hub.cryointhecloud.com/user/mfisher87/myst-build/workshop-open-source-geospatial`.
+
+At this point you should see the build progress in your browser.
+It should only take a few seconds, and then you'll see your fully-built MyST site!
+
+
+### Subsequent builds
+
+Your site will not automatically rebuild when you make changes!
+This functionality will be available in the future.
+
+Append  `/?rebuild=1` to the URL to trigger a rebuild.


### PR DESCRIPTION

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--23.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->