### PR TITLE
Style guide: Clarify usage of Notebooks instead of Markdown in materials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Jupyter ephemera
+.ipynb_checkpoints
 
 # pixi environments
 .pixi

--- a/for-instructors/style-guide.md
+++ b/for-instructors/style-guide.md
@@ -33,8 +33,20 @@ Diátaxis is a fantastic resource for writing documentation for various audience
   Goal: Provide in-depth understanding of a concept, often linking multiple concepts
   together or explaining a technical decision, architecture, or history.
 
+## Repository structure
 
-## Structure
+### Notebooks vs. Markdown
+
+Notebooks and Markdown can be used interchangeably.
+This means the content for your module can be stored in `index.md` or `index.ipynb`.
+
+Supporting Notebooks can be stored as neighbors to your index file, and your Notebooks
+can link to each other.
+When participants open the Notebooks in JupyterLab they can click the links to
+automatically open other Notebooks.
+
+
+## Content structure
 
 All modules should have a consistent structure!
 

--- a/myst.yml
+++ b/myst.yml
@@ -16,7 +16,7 @@ project:
     - pattern: "0*.md"
     - title: "Modules"
       children:
-        - pattern: "modules/0*/index.md"
+        - pattern: "modules/0*/index.{md,ipynb}"
     - title: "Reference"
       children:
         - pattern: "reference/*.md"


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--24.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->