### PR TITLE
Add `bash-completion` apt package

### DIFF
--- a/docker/apt.txt
+++ b/docker/apt.txt
@@ -1,4 +1,5 @@
 # Unix utilities
+bash-completion
 man
 man-db
 manpages-posix


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--25.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->