### PR TITLE
Upgrade jupyter-myst-build-proxy: no more URL editing!

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -56,4 +56,4 @@ dependencies:
   # Pip-only dependencies... ideally we get these on conda-forge.
   - "pip"
   - pip:
-    - "jupyter-myst-build-proxy"  # Automatic build and proxying of MyST sites, triggered by requests to `$PREFIX/myst-build/$PATH_TO_MYST_PROJECT`
+    - "jupyter-myst-build-proxy >=0.5.0"


### PR DESCRIPTION
Officially endorsed by a MyST developer as "cursed" :grin: 

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--35.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->