### PR TITLE
Set up jupyter-myst-build-proxy to inject a "Rebuild" button post-build

### DIFF
--- a/docker/start
+++ b/docker/start
@@ -9,4 +9,7 @@ set -euo pipefail
 export GH_SCOPED_CREDS_CLIENT_ID="Iv1.bd27058fd393e285"
 export GH_SCOPED_CREDS_APP_URL="https://github.com/apps/cryocloud-github-access"
 
+# Enable jupyter-myst-build-proxy post-build step which adds a nice Rebuild button
+export JUPYTER_MYST_BUILD_PROXY_POSTBUILD="true"
+
 exec "$@"


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--37.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->