### PR TITLE
Get jupyter-myst-build-proxy from conda-forge

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -41,6 +41,7 @@ dependencies:
   # Publishing
   - "mystmd"
   - "typst"
+  - "jupyter-myst-build-proxy >=0.5.0"
 
   # Testing and validation
   - "ruff"
@@ -52,8 +53,3 @@ dependencies:
 
   # Infrastructure
   - "jupyter-server-proxy"  # Enable proxying MyST sites built from CLI, accessed at `$PREFIX/proxy/$PORT`
-
-  # Pip-only dependencies... ideally we get these on conda-forge.
-  - "pip"
-  - pip:
-    - "jupyter-myst-build-proxy >=0.5.0"


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--38.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->