### PR TITLE
Upgrade jupyter-myst-build-proxy to 0.5.1 for bugfix

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -41,7 +41,7 @@ dependencies:
   # Publishing
   - "mystmd"
   - "typst"
-  - "jupyter-myst-build-proxy >=0.5.0"
+  - "jupyter-myst-build-proxy >=0.5.1"
 
   # Testing and validation
   - "ruff"


### PR DESCRIPTION
<https://github.com/ryanlovett/jupyter-myst-build-proxy/issues/20>

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--42.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->