### PR TITLE
Update MyST reference instructions to use new UX

### DIFF
--- a/reference/04-using-myst.md
+++ b/reference/04-using-myst.md
@@ -24,7 +24,7 @@ top-right of your site, which you can click to trigger a new build of your site.
 Do this every time you make a change to see if it worked correctly!
 
 
-## How this works
+### How this works
 
 This functionality is provided by the extension
 [`jupyter-myst-build-proxy`](https://github.com/ryanlovett/jupyter-myst-build-proxy/).


### PR DESCRIPTION
Instead of URL editing, the user will have features in the user interface to enable them to build and rebuild their MyST site.

This is a compromise, not our end goal; we want the skills they use in the JupyterLab environment to be low-frication _and_ portable to their local machine. I.e. we want them to use `myst start`. This is currently not possible, and the MyST team expects it may take a month or more.

This is made possible by https://github.com/ryanlovett/jupyter-myst-build-proxy/

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--43.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->