### PR TITLE
Fix scroll jumping behavior

### DIFF
--- a/docker/overrides.json
+++ b/docker/overrides.json
@@ -1,0 +1,8 @@
+{
+  "@jupyterlab/notebook-extension:tracker": {
+    "scrollPastEnd": false
+  },
+  "@jupyterlab/apputils-extension:notification": {
+    "fetchNews": "false"
+  }
+}

--- a/docker/postBuild
+++ b/docker/postBuild
@@ -7,3 +7,7 @@ set -euo pipefail
 # used in the JupyterHub.
 cp custom_jupyter_server_config.json ${NB_PYTHON_PREFIX}/etc/jupyter/jupyter_server_config.d/
 cp custom_jupyter_server_config.json ${NB_PYTHON_PREFIX}/etc/jupyter/jupyter_notebook_config.d/
+
+# Install settings overrides, including fix for jumping-scroll behavior
+mkdir -p ${NB_PYTHON_PREFIX}/share/jupyter/lab/settings
+cp overrides.json ${NB_PYTHON_PREFIX}/share/jupyter/lab/settings


### PR DESCRIPTION
I was experiencing jumping scroll playing with module 4's notebook. This setting worked for me. This is fixed in JupyterLab 4.5, but JupyterGIS is stuck at 4.4.x.

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--46.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->