### PR TITLE
Upgrade MyST in Docker image

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -39,7 +39,7 @@ dependencies:
   - "maplibre"
 
   # Publishing
-  - "mystmd"
+  - "mystmd >=1.6.6"
   - "typst"
   - "jupyter-myst-build-proxy >=0.5.1"
 


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--49.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->