### PR TITLE
Remove the "Foo" :laughing:

### DIFF
--- a/modules/05-sharing-and-publishing/index.md
+++ b/modules/05-sharing-and-publishing/index.md
@@ -156,8 +156,6 @@ process.
 ::::::{hint} Joining late? You may need to clone the workshop repository
 :class: dropdown
 
-Foo!
-
 If you're joining late, you may have missed a prior instruction to clone the workshop
 website and set up GitHub authentication.
 


### PR DESCRIPTION
Woopsie! I was using this text as a trigger for demonstrating a MyST behavior and then I committed it. I should have expected that :laughing: 

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--54.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->