### PR TITLE
Add data access, zonal statistics, and convenience dependencies

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -30,6 +30,9 @@ dependencies:
   - "shapely"
   - "fiona"
   - "pystac-client"
+  - "odc-stac"
+  - "ibis-duckdb"
+  - "exactextract"
 
   # geo viz
   - "jupytergis >=0.9.2"


### PR DESCRIPTION
exactextract is for zonal statistics

jupyterlab_execution_time is for showing the time it takes a cell to execute at the bottom. Good for exercises with potentially-long-running cells. E.g. helps students understand "does increasing the amount of RAM reduce execution time meaningfully?"