### PR TITLE
Unset BASE_URL for custom DNS deployment

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -5,9 +5,6 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
-env:
-  BASE_URL: "/${{ github.event.repository.name }}"
-
 
 # Allow one concurrent deployment
 concurrency:


### PR DESCRIPTION
We're now deployed at <https://agu2025.workshops.geojupyter.org/> so we no longer need the BASE_URL that was useful when we were deployed at GH Pages <https://geojupyter.github.io/workshop-open-source-geospatial>.

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--57.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->