### PR TITLE
Fixup links to old workshop URL

### DIFF
--- a/modules/02-interactive-viz/index.ipynb
+++ b/modules/02-interactive-viz/index.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "This notebook is for the workshop ([Open Source Geospatial Workflows in the Cloud](https://geojupyter.github.io/workshop-open-source-geospatial)) presented at the [AGU Fall Meeting 2025](https://agu.confex.com/agu/agu25/meetingapp.cgi/Session/252640).\n",
+    "This notebook is for the workshop ([Open Source Geospatial Workflows in the Cloud](https://agu2025.workshops.geojupyter.org/)) presented at the [AGU Fall Meeting 2025](https://agu.confex.com/agu/agu25/meetingapp.cgi/Session/252640).\n",
     "\n",
     "### Learning Objectives\n",
     "\n",

--- a/modules/03-integrating-ai/index.ipynb
+++ b/modules/03-integrating-ai/index.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "This notebook is for the workshop ([Open Source Geospatial Workflows in the Cloud](https://geojupyter.github.io/workshop-open-source-geospatial)) presented at the [AGU Fall Meeting 2025](https://agu.confex.com/agu/agu25/meetingapp.cgi/Session/252640).\n",
+    "This notebook is for the workshop ([Open Source Geospatial Workflows in the Cloud](https://agu2025.workshops.geojupyter.org/)) presented at the [AGU Fall Meeting 2025](https://agu.confex.com/agu/agu25/meetingapp.cgi/Session/252640).\n",
     "\n",
     "**GeoAI** represents the intersection of geospatial science and artificial intelligence, combining the power of machine learning with geographic information systems (GIS) to analyze, understand, and predict spatial patterns. This rapidly growing field enables us to extract meaningful insights from satellite imagery, aerial photos, and other geospatial datasets at unprecedented scales and accuracy levels.\n",
     "\n",


### PR DESCRIPTION
Now that we're at <https://agu2025.workshops.geojupyter.org/> we should update these links :D