### PR TITLE
Upgrade JupyterGIS >=0.10.1

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -35,7 +35,7 @@ dependencies:
   - "exactextract"
 
   # geo viz
-  - "jupytergis >=0.9.2"
+  - "jupytergis >=0.10.1"
   - "leafmap"
   - "folium"
   - "cartopy"


### PR DESCRIPTION
Includes bugfixes enabling module 6 demo

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--60.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->