### PR TITLE
Upgrade MyST and jupyter-myst-build-proxy

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -43,9 +43,9 @@ dependencies:
   - "maplibre"
 
   # Publishing
-  - "mystmd >=1.6.6"
+  - "mystmd >=1.7.0"
   - "typst"
-  - "jupyter-myst-build-proxy >=0.5.1"
+  - "jupyter-myst-build-proxy >=0.6.0"
 
   # Testing and validation
   - "ruff"


### PR DESCRIPTION
This will fail for an hour or so until the package hits the Anaconda CDN

Resolves #71 

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--72.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->