### PR TITLE
Convert relative paths to absolute paths

### DIFF
--- a/for-instructors/dogfooding.md
+++ b/for-instructors/dogfooding.md
@@ -10,9 +10,9 @@ our users will use on the day of the workshop.
 
 You'll need to be familiar with the following processes:
 
-* [](../reference/01-starting-your-server.md)
-* [](../reference/02-stopping-your-server.md)
-* [](../reference/03-gh-auth.md)
+* [](/reference/01-starting-your-server.md)
+* [](/reference/02-stopping-your-server.md)
+* [](/reference/03-gh-auth.md)
 
 Once you've set up GitHub authentication, you can use Git normally.
 
@@ -23,7 +23,7 @@ We have installed
 [`jupyter-myst-build-proxy`](https://github.com/ryanlovett/jupyter-myst-build-proxy)
 which builds the MyST site on-demand.
 
-See [](../reference/04-using-myst.md) for instructions.
+See [](/reference/04-using-myst.md) for instructions.
 
 
 ### Tradeoffs

--- a/for-instructors/style-guide.md
+++ b/for-instructors/style-guide.md
@@ -129,7 +129,7 @@ Follow the [Diátaxis](https://diataxis.fr) principles for your audience!
 
 ### Vocabulary
 
-All vocabulary should be defined in the [](../reference/00-vocabulary.md) page.
+All vocabulary should be defined in the [](/reference/00-vocabulary.md) page.
 Follow the pre-existing pattern to add new terms.
 
 References should be conscious of case.

--- a/joining-late.md
+++ b/joining-late.md
@@ -4,7 +4,7 @@
 If you're joining late, you may have missed a prior instruction to start your CryoCloud server,
 clone the workshop website and set up GitHub authentication.
 
-To start your CryoCloud server, visit the reference section [](../../reference/01-starting-your-server.md).
+To start your CryoCloud server, visit the reference section [](/reference/01-starting-your-server.md).
 
 To clone the workshop repository, open a terminal in your CryoCloud JupyterLab server:
 
@@ -29,5 +29,5 @@ Resolving deltas: 100% (229/229), done.
 
 **Finally, you'll need to setup GitHub authentication to push to GitHub**, which is required to
 complete some modules (e.g. module 5).
-Please follow the instructions at [](../../reference/03-gh-auth.md).
+Please follow the instructions at [](/reference/03-gh-auth.md).
 ::::::

--- a/modules/05-sharing-and-publishing/index.md
+++ b/modules/05-sharing-and-publishing/index.md
@@ -106,7 +106,7 @@ instance with MyST pre-installed.
 CryoCloud also comes with a special configuration for building a MyST site without the
 use of the terminal.
 
-To preview a MyST site in JupyterLab, view instructions in the reference section [](../../reference/04-using-myst.md).
+To preview a MyST site in JupyterLab, view instructions in the reference section [](/reference/04-using-myst.md).
 
 :::{note} The normal way (without JupyterLab)
 :class: dropdown

--- a/reference/01-starting-your-server.md
+++ b/reference/01-starting-your-server.md
@@ -12,7 +12,7 @@ exist after you stop and restart your server.**
 Once you're logged in to [the CryoCloud JupyterHub](https://hub.cryointhecloud.com),
 you'll be presented with a screen like this:
 
-![](../assets/images/cryocloud-server-options.png)
+![](/assets/images/cryocloud-server-options.png)
 
 Select:
 
@@ -38,6 +38,6 @@ using it.
 When you click start, CryoCloud will begin creating your personal server.
 You should see a progress bar like this:
 
-![](../assets/images/cryocloud-server-starting.png)
+![](/assets/images/cryocloud-server-starting.png)
 
 After a few moments, you'll be presented with the JupyterLab interface.

--- a/reference/02-stopping-your-server.md
+++ b/reference/02-stopping-your-server.md
@@ -11,7 +11,7 @@ Your "Hub Control Panel" allows you to manage your server.
 
 To access the control panel, click **File**, then **Hub Control Panel**.
 
-![](../assets/images/cryocloud-hub-control-panel.png)
+![](/assets/images/cryocloud-hub-control-panel.png)
 
 Click **Stop My Server**, and wait a few seconds.
 Once your server is stopped, the **Stop My Server** button will disappear.


### PR DESCRIPTION
Relative, as in "relative to the current file".
Absolute, as in "relative to the project root".

Absolute paths are more readable, require less cognitive load (i.e. you don't need to know the location of the current file to understand the location of the target file), and more portable.

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--73.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->