### PR TITLE
Fix small typo in notebook path.

### DIFF
--- a/modules/06-geojupyter/index.md
+++ b/modules/06-geojupyter/index.md
@@ -30,7 +30,7 @@ We'll work through this module together in a Jupyter Notebook!
 :::{include} /joining-late.md
 :::
 
-Open the `demo.md` notebook in the Module 6 directory within the workshop repository.
+Open the `demo.ipynb` notebook in the Module 6 directory within the workshop repository.
 On your CryoCloud server, it should be at
 `workshop-open-source-geospatial/modules/06-geojupyter/demo.ipynb`.
 


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--82.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->