### PR TITLE
Cleanup docker env manifest and upgrade jupyterlab-myst

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -7,9 +7,9 @@ dependencies:
 
   # Some cool extensions
   - "jupyterlab-favorites <3.3.0"  # 3.3.0 seems to introduce a bug duplicating headers in Notebook Markdown cells (https://github.com/jupyterlab-contrib/jupyterlab-favorites/issues/35)
-  - "jupyter-collaboration>=3,<4"
+  - "jupyter-collaboration >=3,<4"
   - "jupyter-server-proxy"
-  - "jupyterlab-myst"
+  - "jupyterlab-myst >=2.6.0"
   - "jupyterlab-geojson"
   - "jupyterlab_execute_time"
   - "nbdime"
@@ -25,14 +25,13 @@ dependencies:
   # Storage
   - "s3fs"
   - "obstore"
-  - "fsspec>=2025.7.0,<2025.11"
-  - "icechunk>=1.1.12"
-  - "virtualizarr>=2.2.1"
-  - "netCDF4>=1.7.2"
-  - "h5netcdf>=1.6.4,<1.8"
-  - "h5py>=3.14.0,<3.15"
-  - "zarr>=3.1.1,<3.2"
-  - "icechunk"
+  - "fsspec >=2025.7.0,<2025.11"
+  - "icechunk >=1.1.12"
+  - "virtualizarr >=2.2.1"
+  - "netCDF4 >=1.7.2"
+  - "h5netcdf >=1.6.4,<1.8"
+  - "h5py >=3.14.0,<3.15"
+  - "zarr >=3.1.1,<3.2"
 
   # Acceleration
   - "bottleneck"
@@ -75,6 +74,3 @@ dependencies:
   # GitHub utilities
   - "gh"
   - "gh-scoped-creds"
-
-  # Infrastructure
-  - "jupyter-server-proxy"  # Enable proxying MyST sites built from CLI, accessed at `$PREFIX/proxy/$PORT`


### PR DESCRIPTION
Ideally, this gets us nicely-styled links in Jupyter Notebooks again :D https://github.com/jupyter-book/jupyterlab-myst/releases/tag/v2.6.0

Removed redundant dependencies "icechunk" and "jupyter-server-proxy"

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--83.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->