### PR TITLE
Fix module 1 callout and link

### DIFF
--- a/modules/01-working-in-jupyterhub/index.md
+++ b/modules/01-working-in-jupyterhub/index.md
@@ -241,7 +241,7 @@ To do this:
 
 ## Task: Activate GitHub authentication
 
-Let's do a quick GitHub authentication to make our lives easier as we access different repositories. This authentication will last 8 hours or until you finish your session, then you will need to do it again if you want to re-authenticate. Instructions are here: [](/reference/gh-auth.md).
+Let's do a quick GitHub authentication to make our lives easier as we access different repositories. This authentication will last 8 hours or until you finish your session, then you will need to do it again if you want to re-authenticate. Instructions are here: [](/reference/03-gh-auth.md).
 
 ---
 


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--91.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->