### PR TITLE
Add full git clone command in module 1

### DIFF
--- a/modules/01-working-in-jupyterhub/index.md
+++ b/modules/01-working-in-jupyterhub/index.md
@@ -233,7 +233,7 @@ To do this:
 3. Now clone the workshop code into your current directory:
 
    ```
-   https://github.com/geojupyter/workshop-open-source-geospatial.git
+   git clone https://github.com/geojupyter/workshop-open-source-geospatial.git
    ```
 
 4. You will see the folder pop into your `File Browser` on the left if you have the current directory open.


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial start -->
---
:mag: Preview: https://geojupyter-workshop-open-source-geospatial--94.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-open-source-geospatial end -->